### PR TITLE
Fixed per NIP-05 specs

### DIFF
--- a/src/components/elements/User/UserProfileHeader.tsx
+++ b/src/components/elements/User/UserProfileHeader.tsx
@@ -55,7 +55,7 @@ export const UserProfileHeader = observer(function UserProfileHeader(props: Prop
           </Text>
           {nip05 && (
             <Text variant='label' size='lg'>
-              {nip05}
+              {nip05.replace(/^_@/, '')}
             </Text>
           )}
         </Stack>


### PR DESCRIPTION
According to [NIP-05 spec](https://github.com/nostr-protocol/nips/blob/master/05.md):

> Clients may treat the identifier `_@domain` as the "root" identifier, and choose to display it as just the `<domain>`. For example, if Bob owns `bob.com`, he may not want an identifier like `bob@bob.com` as that is redundant. Instead, Bob can use the identifier `_@bob.com` and expect Nostr clients to show and treat that as just `bob.com` for all purposes.

I made it so that when the handle is `_`, it is hidden.

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/85cefe74-2c03-431f-8ca1-117d501d4079) | ![After](https://github.com/user-attachments/assets/a935b0e8-3ff0-4db4-b0f0-fa8c8266579a) |
