### PR TITLE
feat: add Spotify embed support for pretty link views

### DIFF
--- a/src/components/elements/Content/Content.tsx
+++ b/src/components/elements/Content/Content.tsx
@@ -17,6 +17,7 @@ import { Heading } from './Markdown/Heading'
 import { List } from './Markdown/List'
 import { NAddr } from './NAddr/NAddr'
 import { NEvent } from './NEvent/NEvent'
+import { Spotify } from './Spotify/Spotify'
 import { Tweet } from './Tweet/Tweet'
 import { Video } from './Video/Video'
 import { YoutubeEmbed } from './Youtube/YoutubeEmbed'
@@ -79,6 +80,7 @@ export const Content = memo(function Content(props: Props) {
               {node.type === 'codeBlock' && <CodeBlock node={node} />}
               {node.type === 'blockquote' && <BlockQuote node={node} />}
               {node.type === 'tweet' && <Tweet src={node.attrs.src} />}
+              {node.type === 'spotify' && <Spotify src={node.attrs.src} />}
               {node.type === 'youtube' && (
                 <MediaWrapper size={size} src={node.attrs.src}>
                   <YoutubeEmbed src={node.attrs.src} />

--- a/src/components/elements/Content/Spotify/Spotify.tsx
+++ b/src/components/elements/Content/Spotify/Spotify.tsx
@@ -1,0 +1,43 @@
+import { useContentContext } from '@/components/providers/ContentProvider'
+import { spacing } from '@/themes/spacing.stylex'
+import React from 'react'
+import { css, html } from 'react-strict-dom'
+
+export type Props = {
+  src: string
+}
+
+export const Spotify = (props: Props) => {
+  const { src } = props
+  const { dense } = useContentContext()
+  
+  // Convert Spotify URL to embed URL
+  const embedUrl = src.replace('open.spotify.com', 'open.spotify.com/embed')
+  
+  return (
+    <html.div style={[styles.root, dense && styles.root$dense]}>
+      <iframe
+        src={embedUrl}
+        width="100%"
+        height="352"
+        frameBorder="0"
+        allowTransparency
+        allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+        loading="lazy"
+        style={styles.iframe as any}
+      />
+    </html.div>
+  )
+}
+
+const styles = css.create({
+  root: {
+    paddingInline: spacing.padding2,
+  },
+  root$dense: {
+    paddingInline: 0,
+  },
+  iframe: {
+    borderRadius: 12,
+  },
+})

--- a/src/components/elements/Content/Spotify/SpotifyEditor.tsx
+++ b/src/components/elements/Content/Spotify/SpotifyEditor.tsx
@@ -1,0 +1,11 @@
+import { NodeViewWrapper, type NodeViewRendererProps } from '@tiptap/react'
+import { Spotify, type Props as SpotifyProps } from './Spotify'
+
+export const SpotifyEditor = (props: NodeViewRendererProps) => {
+  const attrs = props.node.attrs as SpotifyProps
+  return (
+    <NodeViewWrapper data-drag-handle='' draggable={props.node.type.spec.draggable}>
+      <Spotify src={attrs.src} />
+    </NodeViewWrapper>
+  )
+}

--- a/src/components/elements/Content/Spotify/SpotifyExtension.ts
+++ b/src/components/elements/Content/Spotify/SpotifyExtension.ts
@@ -1,0 +1,69 @@
+import { Node } from '@tiptap/core'
+import { ReactNodeViewRenderer } from '@tiptap/react'
+
+export interface SpotifyOptions {
+  inline: boolean
+  HTMLAttributes: Record<string, any>
+}
+
+declare module '@tiptap/core' {
+  interface Commands<ReturnType> {
+    spotify: {
+      insertSpotify: (options: { src: string }) => ReturnType
+    }
+  }
+}
+
+export const SpotifyExtension = Node.create<SpotifyOptions>({
+  name: 'spotify',
+
+  addOptions() {
+    return {
+      inline: false,
+      HTMLAttributes: {},
+    }
+  },
+
+  inline() {
+    return this.options.inline
+  },
+
+  group() {
+    return this.options.inline ? 'inline' : 'block'
+  },
+
+  draggable: true,
+
+  addAttributes() {
+    return {
+      src: {
+        default: null,
+      },
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'div[data-spotify-embed]',
+      },
+    ]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return ['div', { 'data-spotify-embed': '', ...HTMLAttributes }]
+  },
+
+  addCommands() {
+    return {
+      insertSpotify:
+        (options) =>
+        ({ commands }) => {
+          return commands.insertContent({
+            type: this.name,
+            attrs: options,
+          })
+        },
+    }
+  },
+})

--- a/src/components/elements/Editor/utils/createEditor.ts
+++ b/src/components/elements/Editor/utils/createEditor.ts
@@ -2,6 +2,8 @@ import { settingsAtom } from '@/atoms/settings.atoms'
 import { store } from '@/atoms/store'
 import { NEventEditor } from '@/components/elements/Content/NEvent/NEventEditor'
 import { NProfileEditor } from '@/components/elements/Content/NProfile/NProfileEditor'
+import { SpotifyEditor } from '@/components/elements/Content/Spotify/SpotifyEditor'
+import { SpotifyExtension } from '@/components/elements/Content/Spotify/SpotifyExtension'
 import { TweetEditor } from '@/components/elements/Content/Tweet/TweetEditor'
 import { YoutubeEditor } from '@/components/elements/Content/Youtube/YoutubeEditor'
 import type { BlossomOptions } from '@/utils/uploadBlossom'
@@ -107,6 +109,15 @@ export function createEditor(options: Options): UseEditorOptions {
           naddr: addNodeView(NAddrEditor),
           nevent: addNodeView(NEventEditor),
           tweet: addNodeView(TweetEditor),
+        },
+      }),
+      SpotifyExtension.configure({
+        HTMLAttributes: {
+          class: 'spotify-embed',
+        },
+      }).extend({
+        addNodeView() {
+          return ReactNodeViewRenderer(SpotifyEditor)
         },
       }),
     ],

--- a/src/nostr/types.ts
+++ b/src/nostr/types.ts
@@ -24,6 +24,18 @@ export type CustomNode =
       type: 'mediaGroup'
       content: Array<ImageCustomNode | VideoCustomNode>
     }
+  | {
+      type: 'tweet'
+      attrs: { src: string }
+    }
+  | {
+      type: 'youtube'  
+      attrs: { src: string }
+    }
+  | {
+      type: 'spotify'
+      attrs: { src: string }
+    }
 
 export type ContentCustomSchema = Omit<ContentSchema, 'content'> & {
   content: Array<CustomNode>

--- a/src/utils/welshmanToProsemirror.ts
+++ b/src/utils/welshmanToProsemirror.ts
@@ -9,8 +9,9 @@ const VIDEO_EXTENSIONS = /\.(webm|mp4|ogg|mov)$/
 const YOUTUBE_EMBED =
   /^(?:(?:https?:)?\/\/)?(?:(?:(?:www|m(?:usic)?)\.)?youtu(?:\.be|be\.com)\/(?:shorts\/|live\/|v\/|e(?:mbed)?\/|watch(?:\/|\?(?:\S+=\S+&)*v=)|oembed\?url=https?%3A\/\/(?:www|m(?:usic)?)\.youtube\.com\/watch\?(?:\S+=\S+&)*v%3D|attribution_link\?(?:\S+=\S+&)*u=(?:\/|%2F)watch(?:\?|%3F)v(?:=|%3D))?|www\.youtube-nocookie\.com\/embed\/)([\w-]{1})[?&#]?\S*$/
 const TWITTER_EMBED = /^https?:\/\/(twitter|x)\.com\/(?:#!\/)?(\w+)\/status(es)?\/(\d+)/
+const SPOTIFY_EMBED = /^https?:\/\/open\.spotify\.com\/(track|album|playlist|artist|episode|show)\/([a-zA-Z0-9]+)/
 
-type LinkKinds = 'text' | 'image' | 'video' | 'tweet' | 'youtube'
+type LinkKinds = 'text' | 'image' | 'video' | 'tweet' | 'youtube' | 'spotify'
 
 function getLinkKind(url: string): LinkKinds {
   if (YOUTUBE_EMBED.test(url)) {
@@ -18,6 +19,9 @@ function getLinkKind(url: string): LinkKinds {
   }
   if (TWITTER_EMBED.test(url)) {
     return 'tweet'
+  }
+  if (SPOTIFY_EMBED.test(url)) {
+    return 'spotify'
   }
 
   try {
@@ -166,6 +170,11 @@ export function welshmanToProseMirror(welshmanSchema: Parsed[], blockNodesOption
             case 'youtube': {
               pushParagraph()
               result.content.push({ type: 'youtube', attrs: { src: url } })
+              break
+            }
+            case 'spotify': {
+              pushParagraph()
+              result.content.push({ type: 'spotify', attrs: { src: url } })
               break
             }
           }


### PR DESCRIPTION
- Add Spotify URL detection regex pattern for open.spotify.com links
- Create Spotify component with iframe embed rendering
- Create SpotifyEditor for tiptap integration
- Add SpotifyExtension as custom tiptap node
- Update Content.tsx to render Spotify embeds
- Add Spotify types to CustomNode interface
- Support tracks, albums, playlists, artists, episodes, and shows

Follows the same pattern as existing Twitter and YouTube embeds.